### PR TITLE
Replace deprecated async_get_device with async_get_device_by_identifier

### DIFF
--- a/custom_components/anker_solix_official/coordinator.py
+++ b/custom_components/anker_solix_official/coordinator.py
@@ -982,8 +982,8 @@ class AnkerSolixOfficialCoordinator(DataUpdateCoordinator):
                             and self.device_info.get("model") != "--"
                         ):
                             dev_reg = dr.async_get(self.hass)
-                            device = dev_reg.async_get_device(
-                                identifiers={(DOMAIN, self.entry.entry_id)}
+                            device = dev_reg.async_get_device_by_identifier(
+                                (DOMAIN, self.entry.entry_id)
                             )
                             if device:
                                 dev_reg.async_update_device(


### PR DESCRIPTION
**Summary**  
This PR updates the Anker Solix integration to use the new Home Assistant device registry API.
The integration currently calls device_registry.async_get_device, which is deprecated and scheduled for removal in Home Assistant 2027.8.0.
Replacing it ensures long‑term compatibility and removes the deprecation warning from the logs.

**Issue**
Home Assistant logs the following warning:
`Detected that custom integration 'anker_solix_official' calls `device_registry.async_get_device`,
which is deprecated because device identifiers and connections are no longer unique across config entries;
use `async_get_device_by_identifier`, `async_get_device_by_connection` or `async_get_devices` instead.
This will stop working in Home Assistant 2027.8.0.
`
The deprecated call is located in coordinator.py.

**Fix**
`- device = dev_reg.async_get_device(identifiers={(DOMAIN, device_id)})
+ device = dev_reg.async_get_device_by_identifier((DOMAIN, device_id))
`
This is a direct and safe replacement, as the integration uses a single identifier per device.

**Additional Notes**
This PR ensures long‑term compatibility and prevents the integration from breaking once Home Assistant removes the deprecated API in version 2027.8.0.